### PR TITLE
update for ruby2

### DIFF
--- a/lib/excelinator.rb
+++ b/lib/excelinator.rb
@@ -3,14 +3,14 @@ require 'excelinator/rails'
 require 'excelinator/version'
 require 'spreadsheet'
 
-def ruby19?
-  RUBY_VERSION =~ /1.9/
+def old_ruby?
+  RUBY_VERSION.to_f < 1.9
 end
 
-if ruby19?
-  require 'csv'
-else
+if old_ruby?
   require 'fastercsv'
+else
+  require 'csv'
 end
 
 if defined?(Rails)

--- a/lib/excelinator/xls.rb
+++ b/lib/excelinator/xls.rb
@@ -8,7 +8,7 @@ module Excelinator
   end
 
 def self.csv_to_xls(csv_content)
-    ary = (ruby19? ? CSV : FasterCSV).parse(csv_content)
+    ary = (!old_ruby? ? CSV : FasterCSV).parse(csv_content)
 
     book = Spreadsheet::Workbook.new
     sheet = book.create_worksheet

--- a/spec/excelinator_spec.rb
+++ b/spec/excelinator_spec.rb
@@ -34,7 +34,7 @@ describe Excelinator do
 
   it "should not detect table and convert CSV" do
     # due to string encoding issues beyond my comprehension, ruby1.9 makes a bad guess on the header, this fixes it
-    compare_string = ruby19? ? one_two_three_xls.force_encoding('US-ASCII') : one_two_three_xls
+    compare_string = !old_ruby? ? one_two_three_xls.force_encoding('US-ASCII') : one_two_three_xls
 
     # mini-gold standard test: pre-calculated the Excel header bytes and merely that part to match
     Excelinator.convert_content([1, 2, 3].join(','))[0..7].should == compare_string

--- a/testapps/rails2app/app/views/foo/_all.erb
+++ b/testapps/rails2app/app/views/foo/_all.erb
@@ -2,7 +2,7 @@
 
   arabic_only ||= @arabic_only
   words = generate_words_array(arabic_only)
-  (ruby19? ? CSV : FasterCSV).generate do |csv|
+  (!old_ruby? ? CSV : FasterCSV).generate do |csv|
     10.times do
       csv << 10.times.inject([]) { |ary, i| ary << words.sample  }
     end

--- a/testapps/rails2app/app/views/foo/xls_view_respond_to.xls.erb
+++ b/testapps/rails2app/app/views/foo/xls_view_respond_to.xls.erb
@@ -2,7 +2,7 @@
 
   arabic_only ||= @arabic_only
   words = generate_words_array(arabic_only)
-  (ruby19? ? CSV : FasterCSV).generate do |csv|
+  (!old_ruby? ? CSV : FasterCSV).generate do |csv|
     10.times do
       csv << 10.times.inject([]) { |ary, i| ary << words.sample  }
     end

--- a/testapps/rails3app/app/views/foo/_all.erb
+++ b/testapps/rails3app/app/views/foo/_all.erb
@@ -2,7 +2,7 @@
 
   arabic_only ||= @arabic_only
   words = generate_words_array(arabic_only)
-  (ruby19? ? CSV : FasterCSV).generate do |csv|
+  (!old_ruby? ? CSV : FasterCSV).generate do |csv|
     10.times do
       csv << 10.times.inject([]) { |ary, i| ary << words.sample  }
     end

--- a/testapps/rails3app/app/views/foo/no_partial.csv.erb
+++ b/testapps/rails3app/app/views/foo/no_partial.csv.erb
@@ -2,7 +2,7 @@
 
   arabic_only ||= @arabic_only
   words = generate_words_array(arabic_only)
-  (ruby19? ? CSV : FasterCSV).generate do |csv|
+  (!old_ruby? ? CSV : FasterCSV).generate do |csv|
     10.times do
       csv << 10.times.inject([]) { |ary, i| ary << words.sample  }
     end

--- a/testapps/rails3app/app/views/foo/xls_view_respond_to.xls.erb
+++ b/testapps/rails3app/app/views/foo/xls_view_respond_to.xls.erb
@@ -2,7 +2,7 @@
 
   arabic_only ||= @arabic_only
   words = generate_words_array(arabic_only)
-  (ruby19? ? CSV : FasterCSV).generate do |csv|
+  (!old_ruby? ? CSV : FasterCSV).generate do |csv|
     10.times do
       csv << 10.times.inject([]) { |ary, i| ary << words.sample  }
     end


### PR DESCRIPTION
Hi!

Thanks for the Gem.

I wanted to update this gem to work with ruby2, as all of the FasterCSV => CSV checks just checked if the ruby version was 1.9

there is a failing encoding test, in the specs, and your caller may need to call force_encoding('UTF-8') before saving the result in a ruby2 env, so I was hoping to possibly get some feedback to make this work, or at least have a pull request for people who may want to try this novel approach to a very annoying problem on Ruby 2.0.

Any help is much appreciated!
