### PR TITLE
Create a new method to convert a CSV file that uses much less memory

### DIFF
--- a/lib/excelinator/xls.rb
+++ b/lib/excelinator/xls.rb
@@ -21,6 +21,24 @@ def self.csv_to_xls(csv_content)
     book.write(ios)
     content
   end
+  
+  #memory ftw
+  def self.csv_to_xls_file(csv_path, file)
+    book = Spreadsheet::Workbook.new
+    sheet = book.create_worksheet
+    
+    CSV.open(csv_path) do |csv|
+      index = 0
+      csv.each do |raw_row|
+        row = sheet.row(index)
+        row.push(*raw_row)
+        index +=1
+      end
+    end
+    
+    book.write(file)
+    file
+  end
 
   # This only strips a <table> out of the html and adds a meta tag for utf-8 support. Excel will open an .xls file
   # with this content and grok it correctly (including formatting); however, many alternate spreadsheet applications


### PR DESCRIPTION
By exposing a method that takes a file path for the CSV, and a file  object, we can save lots of memory in trying to convert a file to an XLS.  I noticed that when I converted a ~10mb file, my memory was spiking by 100s of MB during the copy of the CSV string, opening the file, and writing to  a new string buffer.

This method allows you to give a local path to a csv file, which it will stream and convert one line at a time. It also lets you pass in a file object to inject the content.
